### PR TITLE
Extract method params and return types from jsdoc (#588)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 
 * `generateAnalysis()` now includes PolymerBehavior information in `metadata.polymer.behaviors` collection.
+* Types and descriptions are now extracted from method @param and @returns jsdoc annotations.
 
 ## [2.0.0-alpha.34] - 2017-03-20
 

--- a/src/analysis-format.ts
+++ b/src/analysis-format.ts
@@ -314,14 +314,14 @@ export interface Method extends Feature {
    * undocumented JavaScript function. Argument types can only be read from
    * associated JSDoc via @param tags
    */
-  params?: {name: string, type?: string}[];
+  params?: {name: string, type?: string, description?: string}[];
 
   /**
    * Data describing the method return type. This data may be incomplete.
    * For example, the return type can be detected from a documented JavaScript
    * function with associated JSDoc and a @return tag.
    */
-  return?: {type?: string, desc: string};
+  return?: {type?: string, desc?: string};
 
   privacy: Privacy;
 

--- a/src/model/method.ts
+++ b/src/model/method.ts
@@ -15,11 +15,17 @@
 import {Property, ScannedProperty} from './model';
 
 export interface ScannedMethod extends ScannedProperty {
-  params?: {name: string, type?: string}[];
-  return?: {type?: string, desc: string};
+  params?: MethodParam[];
+  return?: {type?: string, desc?: string};
 }
 
 export interface Method extends Property {
-  params?: {name: string, type?: string}[];
-  return?: {type?: string, desc: string};
+  params?: MethodParam[];
+  return?: {type?: string, desc?: string};
+}
+
+export interface MethodParam {
+  name: string;
+  type?: string;
+  description?: string;
 }

--- a/src/test/polymer/polymer-element-scanner_test.ts
+++ b/src/test/polymer/polymer-element-scanner_test.ts
@@ -86,7 +86,12 @@ suite('PolymerElementScanner', () => {
         },
         customPublicMethod: (foo, bar) => { return foo + bar; },
         _customPrivateMethod: (foo, bar) => { return foo + bar; },
-        /** This is an instance method with JS Doc */
+        /**
+         * This is an instance method with JS Doc
+         * @param {string} foo The first argument.
+         * @param {number} bar The second argument.
+         * @returns {boolean} The return.
+         */
         customPublicMethodWithJsDoc: (foo, bar) => { return foo + bar; },
         customPublicMethodWithClassicFunction: function(foo, bar) { return foo + bar; },
       });
@@ -151,6 +156,19 @@ suite('PolymerElementScanner', () => {
         'customPublicMethodWithJsDoc',
         'customPublicMethodWithClassicFunction',
       ]);
+
+      const jsDocMethod = features[0].methods[2];
+
+      assert.deepEqual(jsDocMethod.return !, {
+        type: 'boolean',
+        desc: 'The return.',
+      });
+
+      assert.deepEqual(
+          jsDocMethod.params!.map((p) => [p.name, p.type, p.description]), [
+            ['foo', 'string', 'The first argument.'],
+            ['bar', 'number', 'The second argument.'],
+          ]);
 
       assert.deepEqual(features[0].properties.map((p) => [p.name, p.type]), [
         ['a', 'boolean'],

--- a/src/test/polymer/polymer2-element-scanner_test.ts
+++ b/src/test/polymer/polymer2-element-scanner_test.ts
@@ -404,7 +404,10 @@ namespaced name.`,
                 name: 'customInstanceFunctionWithJSDoc',
                 description: 'This is the description for ' +
                     'customInstanceFunctionWithJSDoc.',
-                params: [], return: undefined
+                params: [], return: {
+                  desc: 'The number 5, always.',
+                  type: 'Number',
+                },
               },
               {
                 name: 'customInstanceFunctionWithParams',
@@ -416,8 +419,26 @@ namespaced name.`,
                 name: 'customInstanceFunctionWithParamsAndJSDoc',
                 description: 'This is the description for ' +
                     'customInstanceFunctionWithParamsAndJSDoc.',
-                params: [{name: 'a'}, {name: 'b'}, {name: 'c'}],
-                return: undefined,
+                params: [
+                  {
+                    name: 'a',
+                    type: 'Number',
+                    description: 'The first argument',
+                  },
+                  {
+                    name: 'b',
+                    type: 'Number',
+                  },
+                  {
+                    name: 'c',
+                    type: 'Number',
+                    description: 'The third argument',
+                  }
+                ],
+                return: {
+                  desc: 'The number 7, always.',
+                  type: 'Number',
+                },
               },
               {
                 name: 'customInstanceFunctionWithParamsAndPrivateJSDoc',

--- a/src/test/polymer/polymer2-mixin-scanner_test.ts
+++ b/src/test/polymer/polymer2-mixin-scanner_test.ts
@@ -314,7 +314,10 @@ Polymer.TestMixin = Polymer.woohoo(function TestMixin(base) {
           {name: 'customInstanceFunction', params: [], return: undefined},
           {
             name: 'customInstanceFunctionWithJSDoc',
-            params: [], return: undefined,
+            params: [], return: {
+              desc: 'The number 5, always.',
+              type: 'Number',
+            },
           },
           {
             name: 'customInstanceFunctionWithParams',
@@ -322,7 +325,26 @@ Polymer.TestMixin = Polymer.woohoo(function TestMixin(base) {
           },
           {
             name: 'customInstanceFunctionWithParamsAndJSDoc',
-            params: [{name: 'a'}, {name: 'b'}, {name: 'c'}], return: undefined,
+            params: [
+              {
+                name: 'a',
+                type: 'Number',
+                description: 'The first argument',
+              },
+              {
+                name: 'b',
+                type: 'Number',
+              },
+              {
+                name: 'c',
+                type: 'Number',
+                description: 'The third argument',
+              }
+            ],
+            return: {
+              desc: 'The number 7, always.',
+              type: 'Number',
+            },
           },
           {
             name: 'customInstanceFunctionWithParamsAndPrivateJSDoc',

--- a/src/test/static/analysis/simple/analysis.json
+++ b/src/test/static/analysis/simple/analysis.json
@@ -252,12 +252,17 @@
           },
           "params": [
             {
-              "name": "a"
+              "name": "a",
+              "type": "Number"
             },
             {
-              "name": "b"
+              "name": "b",
+              "type": "Number"
             }
           ],
+          "return": {
+            "type": "boolean"
+          },
           "metadata": {}
         },
         {
@@ -276,12 +281,17 @@
           },
           "params": [
             {
-              "name": "a"
+              "name": "a",
+              "type": "Number"
             },
             {
-              "name": "b"
+              "name": "b",
+              "type": "Number"
             }
           ],
+          "return": {
+            "type": "boolean"
+          },
           "metadata": {}
         },
         {
@@ -300,12 +310,17 @@
           },
           "params": [
             {
-              "name": "a"
+              "name": "a",
+              "type": "Number"
             },
             {
-              "name": "b"
+              "name": "b",
+              "type": "Number"
             }
           ],
+          "return": {
+            "type": "boolean"
+          },
           "metadata": {}
         }
       ],

--- a/src/test/static/polymer2/test-element-10.js
+++ b/src/test/static/polymer2/test-element-10.js
@@ -1,4 +1,3 @@
-
 class TestElement extends Polymer.Element {
   static get properties() {
     return {
@@ -27,7 +26,7 @@ class TestElement extends Polymer.Element {
 
   /**
    * This is the description for customInstanceFunctionWithJSDoc.
-   * @returns {Number} - The number 5, always.
+   * @return {Number} - The number 5, always.
    */
   customInstanceFunctionWithJSDoc() {
     return 5;


### PR DESCRIPTION
* Types and descriptions are now extracted from method @param and @returns jsdoc annotations.

* Handle @return as well as @returns.

<!--
  Thanks for the PR!

  If this change has a user visible change (including
  bug fixes, new features, etc) please describe the change in
  CHANGELOG.md.

  If the change is an entirely package-internal reshuffling/refactoring
  should the change not be described in the CHANGELOG.

  Consider also updating the README.

  More info: http://keepachangelog.com/en/0.3.0/
 -->

 - [ ] CHANGELOG.md has been updated
